### PR TITLE
Refactor setLive Method by Extracting Draftable Relations Logic

### DIFF
--- a/src/Concerns/HasDrafts.php
+++ b/src/Concerns/HasDrafts.php
@@ -202,7 +202,7 @@ trait HasDrafts
         $this->shouldCreateRevision = false;
     }
 
-    public function replicateAndAssociateDraftableRelations(Model $model): void
+    public function replicateAndAssociateDraftableRelations(Model $published): void
     {
         collect($this->getDraftableRelations())->each(function (string $relationName) use ($published) {
             $relation = $published->{$relationName}();


### PR DESCRIPTION
This pull request refactors the `setLive` method by extracting the logic responsible for replicating and associating draftable relations with the published model into its own method. This change aims to improve the method's readability, maintainability, and extendibility for future enhancements and custom use-cases. 

Changes
* Introduced a new public method named `replicateAndAssociateDraftableRelations` which encapsulates the logic for handling draftable relations during the publishing process.
* Adjusted the `setLive` method to call the newly created `replicateAndAssociateDraftableRelations` method, thereby simplifying its own logic and focusing on its primary responsibilities.
