### PR TITLE
[Refactor] Refactoring Usage of Dynamic Values in HasDraft Trait

### DIFF
--- a/src/Concerns/HasDrafts.php
+++ b/src/Concerns/HasDrafts.php
@@ -92,7 +92,7 @@ trait HasDrafts
             // This model has been set not to create a revision
             || $this->shouldCreateRevision() === false
             // The record is being soft deleted or restored
-            || $this->isDirty('deleted_at')
+            || $this->isDirty(method_exists($this, 'getDeletedAtColumn') ? $this->getDeletedAtColumn() : 'deleted_at')
             // A listener of the creatingRevision event returned false
             || $this->fireModelEvent('creatingRevision') === false
         ) {
@@ -106,8 +106,8 @@ trait HasDrafts
                 return;
             }
 
-            $revision->created_at = $this->created_at;
-            $revision->updated_at = $this->updated_at;
+            $revision->{$this->getCreatedAtColumn()} = $this->{$this->getCreatedAtColumn()};
+            $revision->{$this->getUpdatedAtColumn()} = $this->{$this->getUpdatedAtColumn()};
             $revision->is_current = false;
             $revision->is_published = false;
 
@@ -337,7 +337,7 @@ trait HasDrafts
     {
         self::withoutEvents(function () {
             $revisionsToKeep = $this->revisions()
-                ->orderByDesc('updated_at')
+                ->orderByDesc($this->getUpdatedAtColumn())
                 ->onlyDrafts()
                 ->withoutCurrent()
                 ->take(config('drafts.revisions.keep'))


### PR DESCRIPTION
This pull request aims to refactor usages in the `HasDraft` trait, specifically addressing instances where column names for soft delete and timestamps were not utilizing dynamic values. Previously, static values such as `CREATED_AT`, `UPDATED_AT`, and `DELETED_AT` were hardcoded, leading to potential issues.

```
class Page extends Model
{
    use SoftDeletes;
    use HasDrafts;

    const CREATED_AT = 'created'; // not taken into account
    const UPDATED_AT = 'modified'; // not taken into account
    const DELETED_AT = 'deleted'; // not taken into account
}
```

**Changes made** :

- Modified strings and properties utilizing the dynamic values (updated_at, modified_at, deleted_at) provided by their respective model methods. This change enhances flexibility and adherence to best practices within Laravel.

**Additional Notes :**

- No breaking changes are introduced by this refactoring and all tests are passing.