### PR TITLE
Keep the updated_at of previous revision correct.

### DIFF
--- a/src/Concerns/HasDrafts.php
+++ b/src/Concerns/HasDrafts.php
@@ -99,15 +99,16 @@ trait HasDrafts
             return;
         }
 
-        $revision = $this->fresh()?->replicate();
+        $updatingModel = $this->fresh();
+        $revision = $updatingModel?->replicate();
 
-        static::saved(function (Model $model) use ($revision): void {
+        static::saved(function (Model $model) use ($updatingModel, $revision): void {
             if ($model->isNot($this)) {
                 return;
             }
 
-            $revision->{$this->getCreatedAtColumn()} = $this->{$this->getCreatedAtColumn()};
-            $revision->{$this->getUpdatedAtColumn()} = $this->{$this->getUpdatedAtColumn()};
+            $revision->{$this->getCreatedAtColumn()} = $updatingModel->{$this->getCreatedAtColumn()};
+            $revision->{$this->getUpdatedAtColumn()} = $updatingModel->{$this->getUpdatedAtColumn()};
             $revision->is_current = false;
             $revision->is_published = false;
 


### PR DESCRIPTION
Hi! While using this package, I stumbled upon something strange.
I seems to be that when editing a record, the `updated_at` timestamp of the previous revision is actually set to 'now', instead of the time that that revision was actually updated.

So, when updating a record multiple times, this was in my database:
```php
[
  ['title' => 'Rev 1', 'updated_at' => '2021-01-02 14:01:00'], // this was created at 14:00
  ['title' => 'Rev 2', 'updated_at' => '2021-01-02 14:02:00'],
  ['title' => 'Rev 3', 'updated_at' => '2021-01-02 14:03:00'],
  ['title' => 'Rev 4', 'updated_at' => '2021-01-02 14:03:00']  // this is the last edit (now)
]
```


While I actually **expected** this:
```php
[
  ['title' => 'Rev 1', 'updated_at' => '2021-01-02 14:00:00'], // this was created at 14:00
  ['title' => 'Rev 2', 'updated_at' => '2021-01-02 14:01:00'],
  ['title' => 'Rev 3', 'updated_at' => '2021-01-02 14:02:00'],
  ['title' => 'Rev 4', 'updated_at' => '2021-01-02 14:03:00']  // this is the last edit (now)
]
```

Could this be a bug? Or is it intended this way?
Well, this PR fixes the issue. Please let me know what you think :)