### PR TITLE
Fixed: deprecated message when using php 8.4. Closes #62

### DIFF
--- a/src/LaravelDraftsServiceProvider.php
+++ b/src/LaravelDraftsServiceProvider.php
@@ -33,11 +33,11 @@ class LaravelDraftsServiceProvider extends PackageServiceProvider
         $this->app[Kernel::class]->prependToMiddlewarePriority(WithDraftsMiddleware::class);
 
         Blueprint::macro('drafts', function (
-            string $uuid = null,
-            string $publishedAt = null,
-            string $isPublished = null,
-            string $isCurrent = null,
-            string $publisherMorphName = null,
+            ?string $uuid = null,
+            ?string $publishedAt = null,
+            ?string $isPublished = null,
+            ?string $isCurrent = null,
+            ?string $publisherMorphName = null,
         ) {
             /** @var Blueprint $this */
             $uuid ??= config('drafts.column_names.uuid', 'uuid');

--- a/src/LaravelDraftsServiceProvider.php
+++ b/src/LaravelDraftsServiceProvider.php
@@ -56,11 +56,11 @@ class LaravelDraftsServiceProvider extends PackageServiceProvider
         });
 
         Blueprint::macro('dropDrafts', function (
-            string $uuid = null,
-            string $publishedAt = null,
-            string $isPublished = null,
-            string $isCurrent = null,
-            string $publisherMorphName = null,
+            ?string $uuid = null,
+            ?string $publishedAt = null,
+            ?string $isPublished = null,
+            ?string $isCurrent = null,
+            ?string $publisherMorphName = null,
         ) {
             /** @var Blueprint $this */
             $uuid ??= config('drafts.column_names.uuid', 'uuid');


### PR DESCRIPTION
Sorry about the delay. Finally back on the project that uses this, so I had the time to address this.

Before in PHP 8.4:

![image](https://github.com/user-attachments/assets/574ba221-c4c4-42fe-9d84-fb6f103e9a36)

After in PHP 8.4:

![image](https://github.com/user-attachments/assets/fd9762db-06ac-47b1-8e76-5e9451251f2a)
