### PR TITLE
Narrow dependabot-auto-merge token scope

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,13 +2,14 @@ name: dependabot-auto-merge
 on: pull_request_target
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      pull-requests: write
     steps:
     
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- Drop top-level write grants from `dependabot-auto-merge.yml`.
- Default workflow-wide token to `contents: read`.
- Grant only `pull-requests: write` on the dependabot job — sufficient for `gh pr merge --auto`, which enables auto-merge via GraphQL. GitHub performs the actual merge later under its own identity, so the workflow token never needs `contents: write`.

Addresses the lingering "workflow permissions are restricted" scanner finding after #84. Two workflows (`php-cs-fixer`, `update-changelog`) still hold job-scoped `contents: write` because they perform auto-commits via `stefanzweifel/git-auto-commit-action` and cannot function without it.