### PR TITLE
Improve Plumb score: pin docker action, Dependabot cooldown, trim release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,7 @@
 /UPGRADING.md       export-ignore
 /phpstan.neon.dist  export-ignore
 /phpstan-baseline.neon  export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/.pre-commit-config.yaml export-ignore
+/.pre-commit        export-ignore
+/rector.php         export-ignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
     groups:

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Run PHP CS Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga
+        uses: docker://oskarstark/php-cs-fixer-ga@sha256:21293a512b8b72cd6dbafe7f82bd06216e933d841d70518d9e606d25b2b6a736 # latest
         with:
           args: --config=.php-cs-fixer.dist.php --allow-risky=yes
 


### PR DESCRIPTION
Addresses the remaining deductions from the [Plumb analysis](https://plumbphp.dev/oddvalue/laravel-drafts) (currently 82/100):

- Pin the `oskarstark/php-cs-fixer-ga` docker action to a digest (the only unpinned action of 13)
- Add a 7 day cooldown for Dependabot updates
- Export-ignore the remaining dev files (`.php-cs-fixer.dist.php`, `.pre-commit-config.yaml`, `.pre-commit/`, `rector.php`) so release archives are clean

Note: the archive change only takes effect from the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)