### PR TITLE
Run PHP CS Fixer from composer instead of the docker action

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -18,10 +18,17 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Run PHP CS Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga@sha256:21293a512b8b72cd6dbafe7f82bd06216e933d841d70518d9e606d25b2b6a736 # latest
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          args: --config=.php-cs-fixer.dist.php --allow-risky=yes
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4
+
+      - name: Run PHP CS Fixer
+        run: ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-risky=yes
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7


### PR DESCRIPTION
The `docker://oskarstark/php-cs-fixer-ga` reference can only be pinned to an image digest, not a commit SHA, so security scanners (including [Plumb](https://plumbphp.dev/oddvalue/laravel-drafts)) count it as unpinned, and Dependabot cannot update docker refs in workflow files at all.

`friendsofphp/php-cs-fixer` is already in require-dev, so run it from vendor instead. All 15 remaining action references are SHA-pinned and Dependabot-updatable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)